### PR TITLE
feat: support DeepL Free API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ By changing the following setting you can choose on which fields this plugin wil
 
 ![](https://github.com/voorhoede/datocms-plugin-translate-fields/raw/main/docs/translate-fields-general-settings.png)
 
-- **Translation service**: You can choose which service will be used to translate. The chosen service will be used and an option to add a api key will be presented automatically.
+- **Translation service**: You can choose which service will be used to translate. The chosen service will be used and an option to add an api key will be presented automatically.
 
 > Options of `Translation service`:
 > * Yandex translate
-> * DEEPL translate
+> * DeepL API Pro
+> * DeepL API Free
 
 - **Api key of `[selected translation service]`**: Add the api key of the translation service that you have selected. The plugin will give errors if the api key isn't added or if the translation service serves an error.
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,7 +8,8 @@ export const fieldsOptions = [
 
 export const translationServiceOptions = [
   { label: 'Yandex translate', value: TranslationService.yandex },
-  { label: 'DEEPL translate', value: TranslationService.deepl },
+  { label: 'DeepL API Pro', value: TranslationService.deepl },
+  { label: 'DeepL API Free', value: TranslationService.deeplFree },
 ]
 
 export const translationFormats = {

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -29,14 +29,15 @@ export async function getTranslation(string: string, options: TranslationOptions
     return response.text.join(' ')
   }
 
-  if (options.translationService === TranslationService.deepl) {
+  if (options.translationService === TranslationService.deepl || options.translationService === TranslationService.deeplFree) {
     params.set('auth_key', options.apiKey)
     params.set('target_lang', options.toLocale)
     params.set('tag_handling', 'xml')
     params.set('text', string)
 
+    const endpoint = options.translationService === TranslationService.deepl ? 'https://api.deepl.com': 'https://api-free.deepl.com'
     const request = await fetch(
-      `https://api.deepl.com/v2/translate?${params.toString()}`,
+      `${endpoint}/v2/translate?${params.toString()}`,
     )
 
     if (request.status !== 200) {

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -10,8 +10,12 @@ const parseHtml = require('html2json')
 
 export async function getTranslation(string: string, options: TranslationOptions): Promise<string> {
   const params = new URLSearchParams()
+  
+  const isDeepL = options.translationService === TranslationService.deepl
+  const isDeepLFree = options.translationService === TranslationService.deeplFree
+  const isYandex = options.translationService === TranslationService.yandex
 
-  if (options.translationService === TranslationService.yandex) {
+  if (isYandex) {
     params.set('key', options.apiKey)
     params.set('lang', options.toLocale)
     params.set('format', 'plain')
@@ -29,15 +33,15 @@ export async function getTranslation(string: string, options: TranslationOptions
     return response.text.join(' ')
   }
 
-  if (options.translationService === TranslationService.deepl || options.translationService === TranslationService.deeplFree) {
+  if (isDeepL || isDeepLFree) {
     params.set('auth_key', options.apiKey)
     params.set('target_lang', options.toLocale)
     params.set('tag_handling', 'xml')
     params.set('text', string)
-
-    const endpoint = options.translationService === TranslationService.deepl ? 'https://api.deepl.com': 'https://api-free.deepl.com'
+    
+    const apiVersion = isDeepLFree ? 'api-free' : 'api'
     const request = await fetch(
-      `${endpoint}/v2/translate?${params.toString()}`,
+       `https://${apiVersion}.deepl.com/v2/translate?${params.toString()}`,
     )
 
     if (request.status !== 200) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,17 +25,20 @@ export enum TranslationFormat {
 export enum TranslationService {
   yandex = 'yandex',
   deepl = 'deepl',
+  deeplFree = 'deeplFree',
 }
 
 export enum TranslationServiceKey {
   yandexKey = 'yandexApiKey',
-  deeplApiKey = 'deeplApiKey'
+  deeplApiKey = 'deeplApiKey',
+  deeplFreeApiKey = 'deeplFreeApiKey'
 }
 
 export type Parameters = {
   translationService?: SettingOption
   [TranslationServiceKey.yandexKey]?: string
   [TranslationServiceKey.deeplApiKey]?: string
+  [TranslationServiceKey.deeplFreeApiKey]?: string
 }
 
 export interface GlobalParameters extends Parameters {


### PR DESCRIPTION
Add support for the DeepL Free API tier. It needs to target another endpoint, but otherwise it functions the same.
This allows you to try out the DeepL service, and switch to the paid plan by switching out the endpoint.

Fixes #1 