### PR TITLE
Chore/fix typo's

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ By changing the following setting you can choose on which fields this plugin wil
 > * Yandex translate
 > * DEEPL translate
 
-- **Api key of `[selected translation service]`**: Add the api key of the translation service that you have selected. The plugin will give errors if the api key isn't added or if the translation service serves an error.
+- **API key of `[selected translation service]`**: Add the API key of the translation service that you have selected. The plugin will give errors if the API key isn't added or if the translation service serves an error.
 
 ## Contributing
 

--- a/src/components/ApiTextField/ApiTextField.tsx
+++ b/src/components/ApiTextField/ApiTextField.tsx
@@ -22,7 +22,7 @@ export default function ApiTextField({
       required
       name={`${option.value}ApiKey`}
       id={`${option.value}ApiKey`}
-      label={`Api key of ${option.label}`}
+      label={`API key of ${option.label}`}
       value={apiKey}
       placeholder="Enter API key"
       textInputProps={{


### PR DESCRIPTION
This pull request includes a few changes to always use 'API' in all caps when used in texts.