### PR TITLE
fix(translation.ts): remove id from structured text block

### DIFF
--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -1,5 +1,5 @@
-import set from 'lodash/set'
-import get from 'lodash/get'
+import { pickBy, get, set } from 'lodash'
+
 import {
   TranslationOptions,
   PathTranslationOptions,
@@ -71,12 +71,12 @@ export async function getTranslation(string: string, options: TranslationOptions
 }
 
 export async function getStructuredTextTranslation(value: any[], options: TranslationOptions): Promise<any[]> {
-  const filteredArray = value.filter(item => item.type !== 'block')
+  const filteredArray = value.map(item => item.type !== 'block' ? item : {type:'block'})
   const filteredObject = makeObject(filteredArray, 'children')
   const allPaths = paths(filteredObject)
 
   const translatedArray = await getTranslationPerPath(
-    value,
+    value.map((item)=> item.type ==='block' ? pickBy(item,(value,key)=> key !== 'id') : item),
     {
       ...options,
       arrayKey: 'children',


### PR DESCRIPTION
Fix two bugs related to Structured text translation in `transition.ts`:

#13 By keeping blocks inside the `filteredArray` the translation works for all the text available in structured text. Without this there was a mismatch in `getTranslationPerPath` with `get(jsonObject,fullPath)` because the path was not correct.

#12 If you just copy the block data with the `id` you won't be able to save the record on Dato because the block id create a bug. To fix this, all blocks inside the Structured text are "stripped" from the `id` attribute when they are translated.