### PR TITLE
Feat/fix seo translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-translate-fields",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-translate-fields",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.192",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datocms-plugin-translate-fields",
   "homepage": "https://github.com/voorhoede/datocms-plugin-translate-fields",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A DatoCMS plugin that gives you the ability to translate `structured-text`, `rich-text`, `string`, `text` and `seo` fields in DatoCMS",
   "engines": {
     "node": ">=16.0.0"

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -140,8 +140,10 @@ export async function getSeoTranslation(
   options: TranslationOptions
 ): Promise<any> {
   return {
-    title: await getTranslation(value.title, options),
-    description: await getTranslation(value.description, options),
+    title: value.title ? await getTranslation(value.title, options) : '',
+    description: value.description
+      ? await getTranslation(value.description, options)
+      : '',
     image: value?.image,
     twitter_card: value?.twitter_card,
   }


### PR DESCRIPTION
Set empty string when no title or description is provided in a seo field. Fixing https://github.com/voorhoede/datocms-plugin-translate-fields/issues/24