### PR TITLE
Hide plugin's button when only 1 locale exists

### DIFF
--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -188,6 +188,11 @@ export default function FieldAddon({ ctx }: Props) {
     ctx.setHeight(0)
     return <></>
   }
+  
+  if (locales.length <= 1) {
+    ctx.setHeight(0)
+    return <></>
+  }
 
   if (!isDefaultLocale) {
     return (

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -184,12 +184,7 @@ export default function FieldAddon({ ctx }: Props) {
     )
   }
 
-  if (fieldHasFieldValue(fieldValue, ctx) && !isDefaultLocale) {
-    ctx.setHeight(0)
-    return <></>
-  }
-  
-  if (locales.length <= 1) {
+  if ((fieldHasFieldValue(fieldValue, ctx) && !isDefaultLocale) || locales.length <= 1) {
     ctx.setHeight(0)
     return <></>
   }


### PR DESCRIPTION
Right now, if there is only 1 locale, the plugin's button still appears but doesn't do anything since there are no locale to translate to:

<img width="228" alt="Capture d’écran 2023-05-30 à 09 22 10" src="https://github.com/voorhoede/datocms-plugin-translate-fields/assets/22396965/2e45e8f9-6c5e-4d3d-bb7a-fb31f3ffebcf">


It would be better for the user experience to simply hide it till another locale is added.