### PR TITLE
Feat/Add DeepL "formality" param to config settings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,6 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and follows [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.XX.0] - 2023-XX-XX
-### Added
-- Ability to use Deepl formality of the translation by adding "Formality level" in the plugin settings
-
 ## [1.9.0] - 2023-06-27
 ### Added
 - Ability to use Deepl Glossaries by adding a glossary_id in the plugin settings

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and follows [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.XX.0] - 2023-XX-XX
+### Added
+- Ability to use Deepl formality of the translation by adding "Formality level" in the plugin settings
+
 ## [1.9.0] - 2023-06-27
 ### Added
 - Ability to use Deepl Glossaries by adding a glossary_id in the plugin settings

--- a/src/components/ApiTextField/ApiTextField.tsx
+++ b/src/components/ApiTextField/ApiTextField.tsx
@@ -1,10 +1,10 @@
 import { TextField } from 'datocms-react-ui'
 import { useState } from 'react'
 
-import {  TSettingOption } from '../../lib/types'
+import {  SettingOption } from '../../lib/types'
 
 type ApiTextFieldProps = {
-  option: TSettingOption<string>
+  option: SettingOption<string>
   value: string
   onBlur: (newValue: string) => void
 }

--- a/src/components/ApiTextField/ApiTextField.tsx
+++ b/src/components/ApiTextField/ApiTextField.tsx
@@ -1,10 +1,10 @@
 import { TextField } from 'datocms-react-ui'
 import { useState } from 'react'
 
-import { SettingOption } from '../../lib/types'
+import {  TSettingOption } from '../../lib/types'
 
 type ApiTextFieldProps = {
-  option: SettingOption
+  option: TSettingOption<string>
   value: string
   onBlur: (newValue: string) => void
 }

--- a/src/components/FormalityField/FormalityField.tsx
+++ b/src/components/FormalityField/FormalityField.tsx
@@ -1,11 +1,12 @@
 import { SelectField } from 'datocms-react-ui'
+import { RenderConfigScreenCtx } from 'datocms-plugin-sdk'
+
 import {
   DeeplFormalityLevel,
   GlobalParameters,
   TSettingOption,
 } from '../../lib/types'
 import { deeplFormalityLevelOptions } from '../../lib/constants'
-import { RenderConfigScreenCtx } from 'datocms-plugin-sdk'
 
 type FormalityFieldProps = {
   ctx: RenderConfigScreenCtx

--- a/src/components/FormalityField/FormalityField.tsx
+++ b/src/components/FormalityField/FormalityField.tsx
@@ -4,13 +4,13 @@ import { RenderConfigScreenCtx } from 'datocms-plugin-sdk'
 import {
   DeeplFormalityLevel,
   GlobalParameters,
-  TSettingOption,
+  SettingOption,
 } from '../../lib/types'
 import { deeplFormalityLevelOptions } from '../../lib/constants'
 
 type FormalityFieldProps = {
   ctx: RenderConfigScreenCtx
-  value: TSettingOption<DeeplFormalityLevel>
+  value: SettingOption<DeeplFormalityLevel>
 }
 
 export default function FormalityField({ ctx, value }: FormalityFieldProps) {

--- a/src/components/FormalityField/FormalityField.tsx
+++ b/src/components/FormalityField/FormalityField.tsx
@@ -1,0 +1,38 @@
+import { SelectField } from 'datocms-react-ui'
+import {
+  DeeplFormalityLevel,
+  GlobalParameters,
+  TSettingOption,
+} from '../../lib/types'
+import { deeplFormalityLevelOptions } from '../../lib/constants'
+import { RenderConfigScreenCtx } from 'datocms-plugin-sdk'
+
+type FormalityFieldProps = {
+  ctx: RenderConfigScreenCtx
+  value: TSettingOption<DeeplFormalityLevel>
+}
+
+export default function FormalityField({ ctx, value }: FormalityFieldProps) {
+  const pluginParameters: GlobalParameters = ctx.plugin.attributes.parameters
+
+  return (
+    <SelectField
+      name="deeplFormalityLevel"
+      id="deeplFormalityLevel"
+      label="DeepL formality level"
+      hint="Level of formality that Deepl uses for translations. Keep in mind not all languages support this feature"
+      value={value}
+      selectInputProps={{
+        options: deeplFormalityLevelOptions,
+      }}
+      placeholder="Select a formality level"
+      onChange={(newValue) => {
+        ctx.updatePluginParameters({
+          ...pluginParameters,
+          deeplFormalityLevel: newValue,
+        })
+        ctx.notice('Settings updated successfully!')
+      }}
+    />
+  )
+}

--- a/src/components/OpenAIConfigFields/OpenAIConfigFields.tsx
+++ b/src/components/OpenAIConfigFields/OpenAIConfigFields.tsx
@@ -21,11 +21,11 @@ type OpenAIConfigFieldsProps = {
   ctx: RenderConfigScreenCtx | RenderManualFieldExtensionConfigScreenCtx
   pluginParameters: Parameters | GlobalParameters
   updateParametersFn: (params: Record<string, unknown>) => Promise<void>
-  options: Array<SettingOption>
+  options: SettingOption<string>[]
   models: Models | null
   openAIApiKey: string | undefined
   error: string
-  selectedModel: SettingOption
+  selectedModel: SettingOption<string>
   temperature: number
   maxTokens: number
   topP: number

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -15,7 +15,6 @@ import {
 import {
   DeeplFormalityLevel,
   GlobalParameters,
-  SettingOption,
   TSettingOption,
   TranslationService,
 } from '../../lib/types'
@@ -31,7 +30,7 @@ type Props = {
 
 export default function ConfigScreen({ ctx }: Props) {
   const pluginParameters: GlobalParameters = ctx.plugin.attributes.parameters
-  const selectedTranslationService: SettingOption =
+  const selectedTranslationService =
     pluginParameters?.translationService || translationServiceOptions[0]
   const selectedFormalityLevel: TSettingOption<DeeplFormalityLevel> =
     pluginParameters?.deeplFormalityLevel || deeplFormalityLevelOptions[0]

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -7,16 +7,23 @@ import {
   FieldGroup,
 } from 'datocms-react-ui'
 
-import { fieldsOptions, translationServiceOptions } from '../../lib/constants'
 import {
+  deeplFormalityLevelOptions,
+  fieldsOptions,
+  translationServiceOptions,
+} from '../../lib/constants'
+import {
+  DeeplFormalityLevel,
   GlobalParameters,
   SettingOption,
+  TSettingOption,
   TranslationService,
 } from '../../lib/types'
 
 import ApiTextField from '../../components/ApiTextField/ApiTextField'
 import { OpenAIConfigFieldsConfigScreen } from '../../components/OpenAIConfigFields/OpenAIConfigFields'
 import GlossaryIdField from '../../components/GlossaryIdField/GlossaryIdField'
+import FormalityField from '../../components/FormalityField/FormalityField'
 
 type Props = {
   ctx: RenderConfigScreenCtx
@@ -26,6 +33,8 @@ export default function ConfigScreen({ ctx }: Props) {
   const pluginParameters: GlobalParameters = ctx.plugin.attributes.parameters
   const selectedTranslationService: SettingOption =
     pluginParameters?.translationService || translationServiceOptions[0]
+  const selectedFormalityLevel: TSettingOption<DeeplFormalityLevel> =
+    pluginParameters?.deeplFormalityLevel || deeplFormalityLevelOptions[0]
 
   return (
     <Canvas ctx={ctx}>
@@ -114,6 +123,12 @@ export default function ConfigScreen({ ctx }: Props) {
                 )
               )
             })}
+
+            {(selectedTranslationService.value === TranslationService.deepl ||
+              selectedTranslationService.value ===
+                TranslationService.deeplFree) && (
+              <FormalityField ctx={ctx} value={selectedFormalityLevel} />
+            )}
 
             {(selectedTranslationService.value === TranslationService.deepl ||
               selectedTranslationService.value ===

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -13,9 +13,7 @@ import {
   translationServiceOptions,
 } from '../../lib/constants'
 import {
-  DeeplFormalityLevel,
   GlobalParameters,
-  SettingOption,
   TranslationService,
 } from '../../lib/types'
 
@@ -32,7 +30,7 @@ export default function ConfigScreen({ ctx }: Props) {
   const pluginParameters: GlobalParameters = ctx.plugin.attributes.parameters
   const selectedTranslationService =
     pluginParameters?.translationService || translationServiceOptions[0]
-  const selectedFormalityLevel: SettingOption<DeeplFormalityLevel> =
+  const selectedFormalityLevel =
     pluginParameters?.deeplFormalityLevel || deeplFormalityLevelOptions[0]
 
   const isDeepl = selectedTranslationService.value === TranslationService.deepl ||

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -15,7 +15,7 @@ import {
 import {
   DeeplFormalityLevel,
   GlobalParameters,
-  TSettingOption,
+  SettingOption,
   TranslationService,
 } from '../../lib/types'
 
@@ -32,7 +32,7 @@ export default function ConfigScreen({ ctx }: Props) {
   const pluginParameters: GlobalParameters = ctx.plugin.attributes.parameters
   const selectedTranslationService =
     pluginParameters?.translationService || translationServiceOptions[0]
-  const selectedFormalityLevel: TSettingOption<DeeplFormalityLevel> =
+  const selectedFormalityLevel: SettingOption<DeeplFormalityLevel> =
     pluginParameters?.deeplFormalityLevel || deeplFormalityLevelOptions[0]
 
   return (

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -35,6 +35,10 @@ export default function ConfigScreen({ ctx }: Props) {
   const selectedFormalityLevel: SettingOption<DeeplFormalityLevel> =
     pluginParameters?.deeplFormalityLevel || deeplFormalityLevelOptions[0]
 
+  const isDeepl = selectedTranslationService.value === TranslationService.deepl ||
+  selectedTranslationService.value ===
+    TranslationService.deeplFree
+
   return (
     <Canvas ctx={ctx}>
       <p>
@@ -123,15 +127,11 @@ export default function ConfigScreen({ ctx }: Props) {
               )
             })}
 
-            {(selectedTranslationService.value === TranslationService.deepl ||
-              selectedTranslationService.value ===
-                TranslationService.deeplFree) && (
+            {isDeepl && (
               <FormalityField ctx={ctx} value={selectedFormalityLevel} />
             )}
 
-            {(selectedTranslationService.value === TranslationService.deepl ||
-              selectedTranslationService.value ===
-                TranslationService.deeplFree) && (
+            {isDeepl && (
               <GlossaryIdField
                 value={pluginParameters?.deeplGlossaryId || ''}
                 onBlur={(newValue) => {

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -24,7 +24,6 @@ import {
   TranslationService,
   TranslationServiceKey,
   OpenAIDefaultValues,
-  SettingOption,
 } from '../../lib/types'
 import {
   deeplFormalityLevelOptions,

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -21,10 +21,10 @@ import {
   TranslationOptions,
   GlobalParameters,
   Parameters,
-  SettingOption,
   TranslationService,
   TranslationServiceKey,
   OpenAIDefaultValues,
+  TSettingOption,
 } from '../../lib/types'
 import {
   deeplFormalityLevelOptions,
@@ -46,14 +46,14 @@ export default function FieldAddon({ ctx }: Props) {
     ctx.plugin.attributes.parameters
   const pluginParameters: Parameters = ctx.parameters
 
-  const translationService: SettingOption =
+  const translationService =
     pluginParameters?.translationService ||
     pluginGlobalParameters?.translationService ||
     translationServiceOptions[0]
 
   const translationServiceValue = useMock
     ? TranslationService.mock
-    : (translationService.value as TranslationService)
+    : (translationService.value)
   const translationServiceApiKey =
     `${translationServiceValue}ApiKey` as TranslationServiceKey
 

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -24,7 +24,7 @@ import {
   TranslationService,
   TranslationServiceKey,
   OpenAIDefaultValues,
-  TSettingOption,
+  SettingOption,
 } from '../../lib/types'
 import {
   deeplFormalityLevelOptions,

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -25,7 +25,6 @@ import {
   TranslationService,
   TranslationServiceKey,
   OpenAIDefaultValues,
-  DeeplFormalityLevel,
 } from '../../lib/types'
 import {
   deeplFormalityLevelOptions,
@@ -86,7 +85,7 @@ export default function FieldAddon({ ctx }: Props) {
 
   const deeplFormalityLevelValue =
     pluginGlobalParameters.deeplFormalityLevel?.value ||
-    (deeplFormalityLevelOptions[0].value as DeeplFormalityLevel)
+    (deeplFormalityLevelOptions[0].value)
 
   const fieldValue: any = get(ctx.formValues, ctx.fieldPath)
   const currentLocale: string = ctx.locale

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -25,8 +25,10 @@ import {
   TranslationService,
   TranslationServiceKey,
   OpenAIDefaultValues,
+  DeeplFormalityLevel,
 } from '../../lib/types'
 import {
+  deeplFormalityLevelOptions,
   translationFormats,
   translationServiceOptions,
 } from '../../lib/constants'
@@ -80,8 +82,11 @@ export default function FieldAddon({ ctx }: Props) {
     OpenAIDefaultValues.topP
 
   const deeplGlossaryId =
-    pluginParameters.deeplGlossaryId ||
-    pluginGlobalParameters.deeplGlossaryId
+    pluginParameters.deeplGlossaryId || pluginGlobalParameters.deeplGlossaryId
+
+  const deeplFormalityLevelValue =
+    pluginGlobalParameters.deeplFormalityLevel?.value ||
+    (deeplFormalityLevelOptions[0].value as DeeplFormalityLevel)
 
   const fieldValue: any = get(ctx.formValues, ctx.fieldPath)
   const currentLocale: string = ctx.locale
@@ -127,6 +132,7 @@ export default function FieldAddon({ ctx }: Props) {
           apiKey: translationApiKey,
           deeplOptions: {
             glossaryId: deeplGlossaryId,
+            formality: deeplFormalityLevelValue,
           },
           openAIOptions: {
             model: modelValue,

--- a/src/entrypoints/FieldAddonConfigScreen/FieldAddonConfigScreen.tsx
+++ b/src/entrypoints/FieldAddonConfigScreen/FieldAddonConfigScreen.tsx
@@ -4,7 +4,6 @@ import { Canvas, Form, SelectField, FieldGroup } from 'datocms-react-ui'
 import { translationServiceOptions } from '../../lib/constants'
 import {
   GlobalParameters,
-  SettingOption,
   Parameters,
   TranslationService,
 } from '../../lib/types'
@@ -22,7 +21,7 @@ export default function ConfigScreen({ ctx }: Props) {
   const pluginGlobalParameters: GlobalParameters =
     ctx.plugin.attributes.parameters
 
-  const selectedTranslationService: SettingOption =
+  const selectedTranslationService =
     pluginParameters?.translationService ||
     pluginGlobalParameters?.translationService ||
     translationServiceOptions[0]

--- a/src/hooks/useOpenAIConfigFields.ts
+++ b/src/hooks/useOpenAIConfigFields.ts
@@ -8,10 +8,9 @@ import {
   Models,
   OpenAIDefaultValues,
   SettingOption,
-  TSettingOption,
 } from '../lib/types'
 
-function getDefaultModel({ models }: { models: Models }): TSettingOption<string>  {
+function getDefaultModel({ models }: { models: Models }): SettingOption<string>  {
   const model = models.find((model) => model.id === OpenAIDefaultValues.model)
   const modelId = model?.id
 

--- a/src/hooks/useOpenAIConfigFields.ts
+++ b/src/hooks/useOpenAIConfigFields.ts
@@ -8,9 +8,10 @@ import {
   Models,
   OpenAIDefaultValues,
   SettingOption,
+  TSettingOption,
 } from '../lib/types'
 
-function getDefaultModel({ models }: { models: Models }): SettingOption {
+function getDefaultModel({ models }: { models: Models }): TSettingOption<string>  {
   const model = models.find((model) => model.id === OpenAIDefaultValues.model)
   const modelId = model?.id
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import FieldAddon from './entrypoints/FieldAddon/FieldAddon'
 import FieldAddonConfigScreen from './entrypoints/FieldAddonConfigScreen/FieldAddonConfigScreen'
 
 import { fieldsOptions } from './lib/constants'
-import { GlobalParameters, SettingOption, Fields } from './lib/types'
+import { GlobalParameters, DatoFieldType } from './lib/types'
 import { render } from './lib/render'
 
 import 'datocms-react-ui/styles.css'
@@ -30,10 +30,10 @@ connect({
         name: 'Translate',
         type: 'addon',
         fieldTypes: [
-          Fields.textField,
-          Fields.stringField,
-          Fields.structuredTextField,
-          Fields.seo,
+          DatoFieldType.textField,
+          DatoFieldType.stringField,
+          DatoFieldType.structuredTextField,
+          DatoFieldType.seo,
         ],
         configurable: true,
       },
@@ -49,7 +49,7 @@ connect({
     const pluginGlobalParameters: GlobalParameters =
       ctx.plugin.attributes.parameters
 
-    const fieldsSettings: SettingOption[] =
+    const fieldsSettings =
       pluginGlobalParameters?.fieldsToEnable || fieldsOptions
 
     const fieldIsLocalized: boolean = field.attributes.localized
@@ -58,7 +58,7 @@ connect({
       (addon) => addon.field_extension === extensionId
     )
     const showOnThisFieldType: boolean = fieldsSettings.some(
-      (setting: SettingOption) => setting.value === field.attributes.field_type
+      (setting) => setting.value === field.attributes.field_type
     )
 
     if (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,11 @@
-import { Fields, Editor, TranslationFormat, TranslationService } from './types'
+import {
+  Fields,
+  Editor,
+  TranslationFormat,
+  TranslationService,
+  DeeplFormalityLevel,
+  TSettingOption,
+} from './types'
 
 export const fieldsOptions = [
   { label: 'String fields', value: Fields.stringField },
@@ -24,3 +31,18 @@ export const translationFormats = {
   [Editor.textarea]: TranslationFormat.plain,
   [Editor.seo]: TranslationFormat.seo,
 }
+
+export const deeplFormalityLevelOptions: TSettingOption<DeeplFormalityLevel>[] =
+  [
+    { label: 'Default', value: DeeplFormalityLevel.default },
+    { label: 'More formal', value: DeeplFormalityLevel.more },
+    { label: 'Less formal', value: DeeplFormalityLevel.less },
+    {
+      label: 'Prefer more formal if available',
+      value: DeeplFormalityLevel.preferMore,
+    },
+    {
+      label: 'Prefer less formal if available',
+      value: DeeplFormalityLevel.preferLess,
+    },
+  ]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,10 +4,10 @@ import {
   TranslationFormat,
   TranslationService,
   DeeplFormalityLevel,
-  TSettingOption,
+  SettingOption,
 } from './types'
 
-export const fieldsOptions: TSettingOption<DatoFieldType>[] =  [
+export const fieldsOptions: SettingOption<DatoFieldType>[] =  [
   { label: 'String fields', value: DatoFieldType.stringField },
   { label: 'Text fields', value: DatoFieldType.textField },
   { label: 'Structured text fields', value: DatoFieldType.structuredTextField },
@@ -15,7 +15,7 @@ export const fieldsOptions: TSettingOption<DatoFieldType>[] =  [
   { label: 'SEO fields', value: DatoFieldType.seo },
 ]
 
-export const translationServiceOptions: TSettingOption<TranslationService>[] = [
+export const translationServiceOptions: SettingOption<TranslationService>[] = [
   { label: 'Yandex translate', value: TranslationService.yandex },
   { label: 'DeepL API Pro', value: TranslationService.deepl },
   { label: 'DeepL API Free', value: TranslationService.deeplFree },
@@ -32,7 +32,7 @@ export const translationFormats = {
   [Editor.seo]: TranslationFormat.seo,
 }
 
-export const deeplFormalityLevelOptions: TSettingOption<DeeplFormalityLevel>[] =
+export const deeplFormalityLevelOptions: SettingOption<DeeplFormalityLevel>[] =
   [
     { label: 'Default', value: DeeplFormalityLevel.default },
     { label: 'More formal', value: DeeplFormalityLevel.more },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
 import {
-  Fields,
+  DatoFieldType,
   Editor,
   TranslationFormat,
   TranslationService,
@@ -7,12 +7,12 @@ import {
   TSettingOption,
 } from './types'
 
-export const fieldsOptions = [
-  { label: 'String fields', value: Fields.stringField },
-  { label: 'Text fields', value: Fields.textField },
-  { label: 'Structured text fields', value: Fields.structuredTextField },
-  { label: 'Modular content fields', value: Fields.richTextField },
-  { label: 'SEO fields', value: Fields.seo },
+export const fieldsOptions: TSettingOption<DatoFieldType>[] =  [
+  { label: 'String fields', value: DatoFieldType.stringField },
+  { label: 'Text fields', value: DatoFieldType.textField },
+  { label: 'Structured text fields', value: DatoFieldType.structuredTextField },
+  { label: 'Modular content fields', value: DatoFieldType.richTextField },
+  { label: 'SEO fields', value: DatoFieldType.seo },
 ]
 
 export const translationServiceOptions: TSettingOption<TranslationService>[] = [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,7 +15,7 @@ export const fieldsOptions = [
   { label: 'SEO fields', value: Fields.seo },
 ]
 
-export const translationServiceOptions = [
+export const translationServiceOptions: TSettingOption<TranslationService>[] = [
   { label: 'Yandex translate', value: TranslationService.yandex },
   { label: 'DeepL API Pro', value: TranslationService.deepl },
   { label: 'DeepL API Free', value: TranslationService.deeplFree },

--- a/src/lib/translation-services/deepl.ts
+++ b/src/lib/translation-services/deepl.ts
@@ -1,4 +1,8 @@
-import { TranslationOptions, TranslationService } from '../types'
+import {
+  DeeplFormalityLevel,
+  TranslationOptions,
+  TranslationService,
+} from '../types'
 
 export default async function translate(
   string: string,
@@ -17,6 +21,13 @@ export default async function translate(
 
   if (options.deeplOptions?.glossaryId) {
     params.set('glossary_id', options.deeplOptions.glossaryId)
+  }
+
+  if (
+    options.deeplOptions?.formality &&
+    options.deeplOptions?.formality !== DeeplFormalityLevel.default
+  ) {
+    params.set('formality', options.deeplOptions?.formality)
   }
 
   const apiVersion =

--- a/src/lib/translation-services/deepl.ts
+++ b/src/lib/translation-services/deepl.ts
@@ -25,9 +25,9 @@ export default async function translate(
 
   if (
     options.deeplOptions?.formality &&
-    options.deeplOptions?.formality !== DeeplFormalityLevel.default
+    options.deeplOptions.formality !== DeeplFormalityLevel.default
   ) {
-    params.set('formality', options.deeplOptions?.formality)
+    params.set('formality', options.deeplOptions.formality)
   }
 
   const apiVersion =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,13 +57,13 @@ export enum DeeplFormalityLevel {
 }
 
 export type Parameters = {
-  translationService?: TSettingOption<TranslationService>
-  model?: TSettingOption<string>
+  translationService?: SettingOption<TranslationService>
+  model?: SettingOption<string>
   temperature?: number
   maxTokens?: number
   topP?: number
   deeplGlossaryId?: string
-  deeplFormalityLevel?: TSettingOption<DeeplFormalityLevel>
+  deeplFormalityLevel?: SettingOption<DeeplFormalityLevel>
   [TranslationServiceKey.yandexKey]?: string
   [TranslationServiceKey.deeplApiKey]?: string
   [TranslationServiceKey.deeplFreeApiKey]?: string
@@ -73,10 +73,10 @@ export type Parameters = {
 
 export interface GlobalParameters extends Parameters {
   autoApply?: boolean
-  fieldsToEnable?: TSettingOption<DatoFieldType>[]
+  fieldsToEnable?: SettingOption<DatoFieldType>[]
 }
 
-export type TSettingOption<T> = {
+export type SettingOption<T> = {
   value: T
   label: string
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,7 +57,7 @@ export enum DeeplFormalityLevel {
 }
 
 export type Parameters = {
-  translationService?: SettingOption
+  translationService?: TSettingOption<TranslationService>
   model?: SettingOption
   temperature?: number
   maxTokens?: number

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export enum Fields {
+export enum DatoFieldType {
   stringField = 'string',
   textField = 'text',
   richTextField = 'rich_text',
@@ -73,7 +73,7 @@ export type Parameters = {
 
 export interface GlobalParameters extends Parameters {
   autoApply?: boolean
-  fieldsToEnable?: SettingOption[]
+  fieldsToEnable?: TSettingOption<DatoFieldType>[]
 }
 
 export type SettingOption = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,7 +58,7 @@ export enum DeeplFormalityLevel {
 
 export type Parameters = {
   translationService?: TSettingOption<TranslationService>
-  model?: SettingOption
+  model?: TSettingOption<string>
   temperature?: number
   maxTokens?: number
   topP?: number
@@ -74,11 +74,6 @@ export type Parameters = {
 export interface GlobalParameters extends Parameters {
   autoApply?: boolean
   fieldsToEnable?: TSettingOption<DatoFieldType>[]
-}
-
-export type SettingOption = {
-  value: string
-  label: string
 }
 
 export type TSettingOption<T> = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,6 +48,14 @@ export enum OpenAIDefaultValues {
   topP = 0,
 }
 
+export enum DeeplFormalityLevel {
+  default = 'default',
+  more = 'more',
+  less = 'less',
+  preferMore = 'prefer_more',
+  preferLess = 'prefer_less',
+}
+
 export type Parameters = {
   translationService?: SettingOption
   model?: SettingOption
@@ -55,6 +63,7 @@ export type Parameters = {
   maxTokens?: number
   topP?: number
   deeplGlossaryId?: string
+  deeplFormalityLevel?: TSettingOption<DeeplFormalityLevel>
   [TranslationServiceKey.yandexKey]?: string
   [TranslationServiceKey.deeplApiKey]?: string
   [TranslationServiceKey.deeplFreeApiKey]?: string
@@ -72,6 +81,11 @@ export type SettingOption = {
   label: string
 }
 
+export type TSettingOption<T> = {
+  value: T
+  label: string
+}
+
 export type TranslationOptions = {
   fromLocale: string
   toLocale: string
@@ -80,6 +94,7 @@ export type TranslationOptions = {
   apiKey: string
   deeplOptions?: {
     glossaryId?: string
+    formality?: DeeplFormalityLevel
   }
   openAIOptions: {
     model: string


### PR DESCRIPTION
👋 Hyea


👯 Description: 
- I've added support for "formality" param which was recently added. User can now add "Formality level" in plugin config settings. By default its set to "default", but other options are available from the select component. 


👁️ Preview:
![image](https://github.com/voorhoede/datocms-plugin-translate-fields/assets/8258455/0ea34327-b6a1-4d80-b4ee-2845e3c9b2fc)



🧷 Whats included in this PR:
- update to changelog.md (WIP, as owner should make some adjustments I believe)
- added FomalityField component (which is SelectField component to display list of possible choices of "formality")
- adjustments to ConfigScreen, FieldAddon, constants, deepl files to support this functionality
- new types in types.ts
  - introduced new `TSettingOption<T>` type, might be useful to transition to this in the future from `SettingOption` which doesn't give full typesafety. This gives the possibility to use ie. `TSettingOption<FieldOptions>`, `TSettingOption<TranslationServiceOptions>` etc :) 



🦦 DeepL API docs (unfortunately I can't link to specific param):
https://www.deepl.com/docs-api/translate-text/translate-text

🦦 More info here regarding formality: 
https://support.deepl.com/hc/en-us/articles/4406432463762-About-the-formal-informal-feature