### PR TITLE
Feat: Add Toggle Button to Translate All Fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 coverage
+.idea

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For this plugin you can configure global settings and configure the plugin per f
 
 - **Auto apply to fields (switch)**: When enabled this will automatically apply the plugin to all `structured-text`, `rich-text`, `string`, `text` and `seo` fields.
 By changing the following setting you can choose on which fields this plugin will be applied.
+- **Enable Show Translate to all languages button (switch)**: When enabled this will show a `Translate to all languages` button on for all English text to translate the field into all available languages.
 
 - **Field where this plugin is enabled (multi select)**: You can choose to which fields the plugin will be applied.
 

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -57,6 +57,20 @@ export default function ConfigScreen({ ctx }: Props) {
               ctx.notice('Settings updated successfully!')
             }}
           />
+          <SwitchField
+            name="showTranslateAll"
+            id="showTranslateAll"
+            label="Show translate to all languages button"
+            hint="If disabled it will not show the Translate to all languages button."
+            value={Boolean(pluginParameters?.showTranslateAll)}
+            onChange={(newValue: boolean) => {
+              ctx.updatePluginParameters({
+                ...pluginParameters,
+                showTranslateAll: newValue,
+              })
+              ctx.notice('Settings updated successfully!')
+            }}
+          />
         </FieldGroup>
 
         {pluginParameters?.autoApply && (

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -257,23 +257,26 @@ export default function FieldAddon({ ctx }: Props) {
     )
   }
 
-  return (
-    <Canvas ctx={ctx}>
-      <Form
-        onSubmit={() =>
-          translateField(locales.filter((locale) => locale !== currentLocale))
-        }
-      >
-        <Button
-          buttonSize="xxs"
-          type="submit"
-          rightIcon={isTranslating ? <Spinner size={24} /> : null}
-          disabled={isTranslating}
+  if (pluginGlobalParameters?.showTranslateAll) {
+    return (
+      <Canvas ctx={ctx}>
+        <Form
+          onSubmit={() =>
+            translateField(locales.filter((locale) => locale !== currentLocale))
+          }
         >
-          Translate to all locales (
-          {locales.filter((locale) => locale !== currentLocale).join(', ')})
-        </Button>
-      </Form>
-    </Canvas>
-  )
+          <Button
+            buttonSize="xxs"
+            type="submit"
+            rightIcon={isTranslating ? <Spinner size={24} /> : null}
+            disabled={isTranslating}
+          >
+            Translate to all locales (
+            {locales.filter((locale) => locale !== currentLocale).join(', ')})
+          </Button>
+        </Form>
+      </Canvas>
+    )
+  }
+  return <></>
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,7 @@ export type Parameters = {
 
 export interface GlobalParameters extends Parameters {
   autoApply?: boolean
+  showTranslateAll?: boolean
   fieldsToEnable?: SettingOption<DatoFieldType>[]
 }
 


### PR DESCRIPTION
The purpose of this feature is to give DatoCMS administrators more control over the translation process, by allowing them to enable or disable the option for content editors to translate all locales at once. This can help ensure content editors focus on translating a single locale at a time, rather than mass-generating translations.