### PR TITLE
Add extra english language support

### DIFF
--- a/src/lib/supported-locales.ts
+++ b/src/lib/supported-locales.ts
@@ -23,6 +23,10 @@ export function getSupportedToLocale(
       switch (localeLower) {
         case 'en':
           return 'EN-US'
+        case 'en-eu':
+          return 'EN-GB'
+        case 'en-ie':
+          return 'EN-GB'
         case 'pt':
           return 'PT-PT'
         default:


### PR DESCRIPTION
Currently the plugin fails when trying to translate en-IE or en-EU due to no native support by deepl. So i mapped them to en-gb.