### PR TITLE
fix: OpenAI max_tokens deprecated & support API retry on request failure

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and follows [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - 2025-09-16
+### Added
+- Retry button for failed API calls next to the error message
+### Fixed
+- deprecated `max_tokens` parameter in OpenAI API is replaced with `max_completion_tokens` and changed label
+
 ## [1.14.1] - 2025-09-01
 ### Fixed
 - Cases where structured fields have a different structure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-translate-fields",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-translate-fields",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "license": "ISC",
       "dependencies": {
         "@types/jest": "^29.5.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datocms-plugin-translate-fields",
   "homepage": "https://github.com/voorhoede/datocms-plugin-translate-fields",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "A DatoCMS plugin that gives you the ability to translate `structured-text`, `rich-text`, `string`, `text`, `seo` and `slug` fields in DatoCMS",
   "engines": {
     "node": ">=18.0.0"

--- a/src/components/OpenAI/OpenAIAddonConfigScreen/OpenAIAddonConfigScreen.tsx
+++ b/src/components/OpenAI/OpenAIAddonConfigScreen/OpenAIAddonConfigScreen.tsx
@@ -17,7 +17,7 @@ export default function OpenAIAddonConfigScreen({
     openAIApiKey,
     selectedModel,
     temperature,
-    maxTokens,
+    maxCompletionTokens,
     topP,
     prompt,
   } = useOpenAIConfigFields({ ctx })
@@ -38,7 +38,7 @@ export default function OpenAIAddonConfigScreen({
       error={error}
       selectedModel={selectedModel}
       temperature={temperature}
-      maxTokens={maxTokens}
+      maxCompletionTokens={maxCompletionTokens}
       topP={topP}
       prompt={prompt}
     />

--- a/src/components/OpenAI/OpenAIConfigFields/OpenAIConfigFields.tsx
+++ b/src/components/OpenAI/OpenAIConfigFields/OpenAIConfigFields.tsx
@@ -76,7 +76,7 @@ export default function OpenAIConfigFields({
         <TextField
           name="maxCompletionTokens"
           id="maxCompletionTokens"
-          label="Max Tokens"
+          label="Max Completion Tokens"
           hint="The maximum number of tokens to generate in the completion. The exact limit varies per model."
           placeholder="100"
           value={maxCompletionTokens}

--- a/src/components/OpenAI/OpenAIConfigFields/OpenAIConfigFields.tsx
+++ b/src/components/OpenAI/OpenAIConfigFields/OpenAIConfigFields.tsx
@@ -10,7 +10,7 @@ type OpenAIConfigFieldsProps = {
   error: string
   selectedModel: SettingOption<string>
   temperature: number
-  maxTokens: number
+  maxCompletionTokens: number
   topP: number
   prompt: string
 }
@@ -23,7 +23,7 @@ export default function OpenAIConfigFields({
   openAIApiKey,
   selectedModel,
   temperature,
-  maxTokens,
+  maxCompletionTokens,
   topP,
   prompt,
 }: OpenAIConfigFieldsProps) {
@@ -74,12 +74,12 @@ export default function OpenAIConfigFields({
         />
 
         <TextField
-          name="maxTokens"
-          id="maxTokens"
+          name="maxCompletionTokens"
+          id="maxCompletionTokens"
           label="Max Tokens"
           hint="The maximum number of tokens to generate in the completion. The exact limit varies per model."
           placeholder="100"
-          value={maxTokens}
+          value={maxCompletionTokens}
           textInputProps={{
             type: 'number',
             min: 0,
@@ -88,7 +88,7 @@ export default function OpenAIConfigFields({
           }}
           onChange={(newValue) => {
             updateParametersFn({
-              maxTokens: Number(newValue),
+              maxCompletionTokens: Number(newValue),
             })
           }}
         />
@@ -116,7 +116,7 @@ export default function OpenAIConfigFields({
           openAIApiKey={openAIApiKey}
           selectedModel={selectedModel}
           temperature={temperature}
-          maxTokens={maxTokens}
+          maxCompletionTokens={maxCompletionTokens}
           topP={topP}
           value={prompt}
           onBlur={(newValue) => {

--- a/src/components/OpenAI/OpenAIConfigScreen/OpenAIConfigScreen.tsx
+++ b/src/components/OpenAI/OpenAIConfigScreen/OpenAIConfigScreen.tsx
@@ -15,7 +15,7 @@ export default function OpenAIConfigScreen({ ctx }: OpenAIConfigScreenProps) {
     openAIApiKey,
     selectedModel,
     temperature,
-    maxTokens,
+    maxCompletionTokens,
     topP,
     prompt,
   } = useOpenAIConfigFields({ ctx })
@@ -37,7 +37,7 @@ export default function OpenAIConfigScreen({ ctx }: OpenAIConfigScreenProps) {
       error={error}
       selectedModel={selectedModel}
       temperature={temperature}
-      maxTokens={maxTokens}
+      maxCompletionTokens={maxCompletionTokens}
       topP={topP}
       prompt={prompt}
     />

--- a/src/components/PromptTextareaField/PromptTextareaField.tsx
+++ b/src/components/PromptTextareaField/PromptTextareaField.tsx
@@ -11,7 +11,7 @@ type PromptTextareaFieldProps = {
   openAIApiKey: string
   selectedModel: SettingOption<string>
   temperature: number
-  maxTokens: number
+  maxCompletionTokens: number
   topP: number
   value: string
   onBlur: (newValue: string) => void
@@ -21,7 +21,7 @@ export default function PromptTextareaField({
   openAIApiKey,
   selectedModel,
   temperature,
-  maxTokens,
+  maxCompletionTokens,
   topP,
   value,
   onBlur,
@@ -59,7 +59,7 @@ export default function PromptTextareaField({
                 openAIOptions: {
                   model: selectedModel.value,
                   temperature,
-                  maxTokens,
+                  maxCompletionTokens,
                   topP,
                   prompt,
                 },

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -243,7 +243,20 @@ export default function FieldAddon({ ctx }: Props) {
   if (hasError) {
     return (
       <Canvas ctx={ctx}>
-        <p className="text-error body--small">{hasError}</p>
+        <p className="text-error body--small">
+          {hasError}
+          &nbsp; &nbsp;
+          <Button
+            className="text-underline"
+            buttonSize="xxs"
+            onClick={() => {
+              setHasError('')
+              translateField([currentLocale], locales[0])
+            }}
+          >
+            Retry
+          </Button>
+        </p>
       </Canvas>
     )
   }

--- a/src/entrypoints/FieldAddon/FieldAddon.tsx
+++ b/src/entrypoints/FieldAddon/FieldAddon.tsx
@@ -77,10 +77,10 @@ export default function FieldAddon({ ctx }: Props) {
     pluginGlobalParameters.temperature ??
     OpenAIDefaultValues.temperature
 
-  const maxTokens =
-    pluginParameters.maxTokens ??
-    pluginGlobalParameters.maxTokens ??
-    OpenAIDefaultValues.maxTokens
+  const maxCompletionTokens =
+    pluginParameters.maxCompletionTokens ??
+    pluginGlobalParameters.maxCompletionTokens ??
+    OpenAIDefaultValues.maxCompletionTokens
 
   const topP =
     pluginParameters.topP ??
@@ -158,7 +158,7 @@ export default function FieldAddon({ ctx }: Props) {
           openAIOptions: {
             model: modelValue,
             temperature,
-            maxTokens,
+            maxCompletionTokens,
             topP,
             prompt,
           },

--- a/src/hooks/useOpenAIConfigFields.ts
+++ b/src/hooks/useOpenAIConfigFields.ts
@@ -72,10 +72,10 @@ export function useOpenAIConfigFields({
     pluginGlobalParameters.temperature ??
     OpenAIDefaultValues.temperature
 
-  const maxTokens =
-    pluginParameters?.maxTokens ??
-    pluginGlobalParameters.maxTokens ??
-    OpenAIDefaultValues.maxTokens
+  const maxCompletionTokens =
+    pluginParameters?.maxCompletionTokens ??
+    pluginGlobalParameters.maxCompletionTokens ??
+    OpenAIDefaultValues.maxCompletionTokens
 
   const topP =
     pluginParameters?.topP ??
@@ -119,7 +119,7 @@ export function useOpenAIConfigFields({
     openAIApiKey,
     selectedModel,
     temperature,
-    maxTokens,
+    maxCompletionTokens,
     topP,
     prompt,
   }

--- a/src/lib/translation-services/openAI.ts
+++ b/src/lib/translation-services/openAI.ts
@@ -20,7 +20,7 @@ export default async function translate(
       messages: [{ role: 'user', content: prompt }],
       model: options.openAIOptions.model,
       temperature: options.openAIOptions.temperature,
-      max_tokens: options.openAIOptions.maxTokens,
+      max_completion_tokens: options.openAIOptions.maxCompletionTokens,
       top_p: options.openAIOptions.topP,
     }),
   }

--- a/src/lib/translation.test.ts
+++ b/src/lib/translation.test.ts
@@ -10,7 +10,7 @@ const tranlationOptions = {
   openAIOptions: {
     model: 'text-davinci-003',
     temperature: 0,
-    maxTokens: 100,
+    maxCompletionTokens: 100,
     topP: 0,
     prompt:
       "Translate the following from the locale '{{fromLocale}}' to the locale '{{toLocale}}': {{value}}",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,7 +51,7 @@ export enum TranslationServiceKey {
 export enum OpenAIDefaultValues {
   model = 'text-davinci-003',
   temperature = 0,
-  maxTokens = 100,
+  maxCompletionTokens = 100,
   topP = 0,
   prompt = "Translate the following from the locale '{{fromLocale}}' to the locale '{{toLocale}}': {{value}}",
 }
@@ -69,7 +69,7 @@ export type Parameters = {
   translationService?: SettingOption<TranslationService>
   model?: SettingOption<string>
   temperature?: number
-  maxTokens?: number
+  maxCompletionTokens?: number
   topP?: number
   prompt?: string
   deeplGlossaryId?: string
@@ -107,7 +107,7 @@ export type TranslationOptions = {
   openAIOptions: {
     model: string
     temperature: number
-    maxTokens: number
+    maxCompletionTokens: number
     topP: number
     prompt: string
   }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -51,6 +51,10 @@ strong,
   color: var(--alert-color);
 }
 
+.text-underline {
+  text-decoration: underline;
+}
+
 pre,
 .code {
   font-family: var(--monospaced-font-family);


### PR DESCRIPTION
## Changes
- **Fixed:** [OpenAI API deprecation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens): replaced `max_tokens` with `max_completion_tokens` and updated label  in the UI
- **Added:** Retry button for failed API calls, allowing users to quickly re-run translation requests  

## Technical Details
- Updated OpenAI request builder to use `max_completion_tokens`  
- Improved error handling to surface clear messages and provide retry option  

## Testing
- Verified translation requests succeed with `gpt-5-mini` using `max_completion_tokens`  
- Confirmed Retry button replays failed requests successfully  
- All existing tests passing

