### PR TITLE
Fix structured text translation for soft line breaks, links, and inline blocks

### DIFF
--- a/src/lib/datocms-helpers.test.ts
+++ b/src/lib/datocms-helpers.test.ts
@@ -1,7 +1,10 @@
 import {
   structuredTextBlockSlate,
   structuredTextCodeSlate,
+  structuredTextInlineBlockSlate,
   structuredTextInlineItemSlate,
+  structuredTextLinkSlate,
+  structuredTextItemLinkSlate,
   structuredTextSlate,
 } from '../mocks/structured-text-mock'
 import { metaArray } from '../mocks/helper-mocks'
@@ -30,6 +33,9 @@ describe('getValueType', () => {
   })
   it('should return id when key is id', () => {
     expect(getValueType('id', 'text', PathType.text)).toBe(PathType.id)
+  })
+  it('should return id when key is item', () => {
+    expect(getValueType('item', '123', PathType.text)).toBe(PathType.id)
   })
   it('should return id when key is blockModelId', () => {
     expect(getValueType('blockModelId', 'text', PathType.text)).toBe(
@@ -69,11 +75,30 @@ describe('getValueType', () => {
       getValueType('structured_text', structuredTextSlate, PathType.text),
     ).toBe(PathType.structured_text)
   })
+  it('should return structured_text when value is an array starting with a link node', () => {
+    expect(
+      getValueType('children', [structuredTextLinkSlate], PathType.text),
+    ).toBe(PathType.structured_text)
+  })
+  it('should return structured_text when value is an array starting with an itemLink node', () => {
+    expect(
+      getValueType('children', [structuredTextItemLinkSlate], PathType.text),
+    ).toBe(PathType.structured_text)
+  })
   it('should return structured_text_block when value is a block inside a structured text slate', () => {
     expect(
       getValueType(
         'structured_text_block',
         structuredTextBlockSlate,
+        PathType.text,
+      ),
+    ).toBe(PathType.structured_text_block)
+  })
+  it('should return structured_text_block when value is an inline block inside a structured text slate', () => {
+    expect(
+      getValueType(
+        'structured_text_inline_block',
+        structuredTextInlineBlockSlate,
         PathType.text,
       ),
     ).toBe(PathType.structured_text_block)

--- a/src/lib/datocms-helpers.ts
+++ b/src/lib/datocms-helpers.ts
@@ -17,22 +17,11 @@ export function isStructuredTextText(value: any): boolean {
   return (
     Boolean(value) &&
     !Array.isArray(value) &&
-    ((Object.keys(value).length === 2 &&
-      'children' in value &&
-      'type' in value) ||
-      (Object.keys(value).length === 3 &&
-        'children' in value &&
-        'type' in value &&
-        'level' in value) ||
-      (Object.keys(value).length === 3 &&
-        'children' in value &&
-        'type' in value &&
-        'style' in value) ||
-      (Object.keys(value).length === 4 &&
-        'children' in value &&
-        'type' in value &&
-        'style' in value &&
-        'level' in value))
+    'children' in value &&
+    'type' in value &&
+    !isStructuredTextBlock(value) &&
+    !isStructuredTextInlineItem(value) &&
+    !isStructuredTextCode(value)
   )
 }
 
@@ -49,7 +38,7 @@ export function isStructuredTextBlock(value: any): boolean {
   return (
     Boolean(value) &&
     !Array.isArray(value) &&
-    value.type === 'block' &&
+    (value.type === 'block' || value.type === 'inlineBlock') &&
     'children' in value &&
     'blockModelId' in value
   )
@@ -117,6 +106,7 @@ export function getValueType(
   if (
     key === 'itemTypeId' ||
     key === 'itemId' ||
+    key === 'item' ||
     key === 'upload_id' ||
     key === 'id' ||
     key === 'blockModelId' ||

--- a/src/lib/translation.test.ts
+++ b/src/lib/translation.test.ts
@@ -160,4 +160,110 @@ describe('getStructuredTextTranslation', () => {
     expect(result[0].children[1].url).toBe('https://example.com')
     expect(result[0].children[2].text).toBe('Translated  please')
   })
+
+  it('should translate text inside itemLink nodes and preserve item reference', async () => {
+    const slateValue = [
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'See ' },
+          {
+            type: 'itemLink',
+            item: '123',
+            itemTypeId: '456',
+            children: [{ text: 'this article' }],
+          },
+        ],
+      },
+    ]
+
+    const result = await getStructuredTextTranslation(
+      slateValue,
+      tranlationOptions,
+    )
+
+    expect(result[0].children[0].text).toBe('Translated See ')
+    expect(result[0].children[1].children[0].text).toBe(
+      'Translated this article',
+    )
+    expect(result[0].children[1].item).toBe('123')
+    expect(result[0].children[1].itemTypeId).toBe('456')
+  })
+
+  it('should not crash on inlineItem nodes', async () => {
+    const slateValue = [
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'Hello ' },
+          {
+            type: 'inlineItem',
+            item: '123',
+            itemTypeId: '456',
+            children: [{ text: '' }],
+          },
+          { text: ' world' },
+        ],
+      },
+    ]
+
+    const result = await getStructuredTextTranslation(
+      slateValue,
+      tranlationOptions,
+    )
+
+    expect(result[0].children[0].text).toBe('Translated Hello ')
+    expect(result[0].children[1].item).toBe('123')
+    expect(result[0].children[2].text).toBe('Translated  world')
+  })
+
+  it('should not crash on block nodes with translatable fields', async () => {
+    const slateValue = [
+      {
+        type: 'paragraph',
+        children: [{ text: 'Before block' }],
+      },
+      {
+        type: 'block',
+        blockModelId: '1',
+        children: [{ text: '' }],
+      },
+    ]
+
+    const result = await getStructuredTextTranslation(
+      slateValue,
+      tranlationOptions,
+    )
+
+    expect(result[0].children[0].text).toBe('Translated Before block')
+    expect(result[1].type).toBe('block')
+    expect(result[1].blockModelId).toBe('1')
+  })
+
+  it('should not crash on inlineBlock nodes', async () => {
+    const slateValue = [
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'Before ' },
+          {
+            type: 'inlineBlock',
+            blockModelId: '1',
+            children: [{ text: '' }],
+          },
+          { text: ' after' },
+        ],
+      },
+    ]
+
+    const result = await getStructuredTextTranslation(
+      slateValue,
+      tranlationOptions,
+    )
+
+    expect(result[0].children[0].text).toBe('Translated Before ')
+    expect(result[0].children[1].type).toBe('inlineBlock')
+    expect(result[0].children[1].blockModelId).toBe('1')
+    expect(result[0].children[2].text).toBe('Translated  after')
+  })
 })

--- a/src/lib/translation.test.ts
+++ b/src/lib/translation.test.ts
@@ -1,4 +1,4 @@
-import { getTranslation } from './translation'
+import { getTranslation, getStructuredTextTranslation } from './translation'
 import { TranslationFormat, TranslationService } from './types'
 
 const tranlationOptions = {
@@ -88,5 +88,76 @@ describe('getTranslation', () => {
         translationService: 'test' as TranslationService,
       }),
     ).rejects.toThrow('No translation service added in the settings')
+  })
+})
+
+describe('getStructuredTextTranslation', () => {
+  it('should translate text spans containing soft line breaks', async () => {
+    const slateValue = [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: 'Line one\nLine two\nLine three',
+          },
+        ],
+      },
+    ]
+
+    const result = await getStructuredTextTranslation(
+      slateValue,
+      tranlationOptions,
+    )
+
+    expect(result[0].children[0].text).toBe(
+      'Translated Line one\nLine two\nLine three',
+    )
+  })
+
+  it('should translate simple text spans', async () => {
+    const slateValue = [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: 'Hello world',
+          },
+        ],
+      },
+    ]
+
+    const result = await getStructuredTextTranslation(
+      slateValue,
+      tranlationOptions,
+    )
+
+    expect(result[0].children[0].text).toBe('Translated Hello world')
+  })
+
+  it('should translate text inside link nodes', async () => {
+    const slateValue = [
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'Click ' },
+          {
+            type: 'link',
+            url: 'https://example.com',
+            children: [{ text: 'here' }],
+          },
+          { text: ' please' },
+        ],
+      },
+    ]
+
+    const result = await getStructuredTextTranslation(
+      slateValue,
+      tranlationOptions,
+    )
+
+    expect(result[0].children[0].text).toBe('Translated Click ')
+    expect(result[0].children[1].children[0].text).toBe('Translated here')
+    expect(result[0].children[1].url).toBe('https://example.com')
+    expect(result[0].children[2].text).toBe('Translated  please')
   })
 })

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -157,10 +157,10 @@ export async function getStructuredTextTranslation(
   let translatedArray = mappedValue
 
   for (const path of allPaths) {
-    if (path.type === PathType.text && path.key === 'text') {
+    if (path.key === 'text') {
       const currentPath = path.path
       const currentString = get(translatedArray, currentPath)
-      if (currentString) {
+      if (currentString && typeof currentString === 'string') {
         const translatedString = await getTranslation(currentString, options)
         set(translatedArray, currentPath, translatedString)
       }

--- a/src/mocks/structured-text-mock.ts
+++ b/src/mocks/structured-text-mock.ts
@@ -37,6 +37,37 @@ export const structuredTextInlineItemSlate = {
   ],
 }
 
+export const structuredTextInlineBlockSlate = {
+  blockModelId: '1',
+  type: 'inlineBlock',
+  children: [
+    {
+      text: 'Test',
+    },
+  ],
+}
+
+export const structuredTextLinkSlate = {
+  type: 'link',
+  url: 'https://example.com',
+  children: [
+    {
+      text: 'Test',
+    },
+  ],
+}
+
+export const structuredTextItemLinkSlate = {
+  type: 'itemLink',
+  item: '1',
+  itemTypeId: '1',
+  children: [
+    {
+      text: 'Test',
+    },
+  ],
+}
+
 export const structuredTextCodeSlate = {
   type: 'code',
   children: [


### PR DESCRIPTION
## Summary

- Fixes #77 — text spans containing `\n` (soft line breaks from Shift+Enter) were silently skipped during translation
- Fixes #73 — inline blocks and other non-standard node types caused errors

### Root causes and fixes

**Soft line breaks (#77):** `getValueType` misclassified text containing `\n` as markdown (matched `markdownparagraph` regex), and `getStructuredTextTranslation` only translated `PathType.text` spans. Fix: check `path.key === 'text'` instead of `path.type === PathType.text`.

**Node type handling (#73):** `isStructuredTextText` used rigid key-count checks that only matched nodes with exact key combinations (`type` + `children`, optionally `level`/`style`). Nodes like `link` (has `url`), `itemLink` (has `item`), and `inlineBlock` were not recognized. Fix:
- Broadened `isStructuredTextText` to recognize any node with `type` + `children` (excluding blocks, inline items, and code)
- Extended `isStructuredTextBlock` to also handle `inlineBlock` nodes
- Added `item` key to the ID protection list in `getValueType`

### Node types now handled

| Node type | Status |
|---|---|
| `softBreak` (`\n` in text) | Fixed — text now translated |
| `link` | Fixed — text translated, URL preserved |
| `itemLink` | Fixed — text translated, item reference preserved |
| `inlineBlock` | Fixed — handled like `block` |
| `inlineItem` | Already worked |
| `block` | Already worked |

## Test plan

- [x] 8 new tests added (105 total, all passing)
- [x] Soft line break text spans are translated
- [x] Link text translated, URLs preserved
- [x] itemLink text translated, item references preserved
- [x] inlineItem nodes preserved without crash
- [x] block nodes preserved without crash
- [x] inlineBlock nodes handled correctly
- [x] All existing tests still pass